### PR TITLE
Fix import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "release": "npmpub"
   },
   "dependencies": {
-    "bs-platform": "^7.0.0",
     "glob": "^7.1.3",
     "mkdirp": "^0.5.1",
     "reason-future": "^2.4.0",
@@ -71,5 +70,8 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "peerDependencies": {
+    "bs-platform": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "release": "npmpub"
   },
   "dependencies": {
+    "bs-platform": "^7.1.0",
     "glob": "^7.1.3",
     "mkdirp": "^0.5.1",
     "reason-future": "^2.4.0",
@@ -70,8 +71,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "peerDependencies": {
-    "bs-platform": "^7.1.0"
   }
 }

--- a/src/Transformer.re
+++ b/src/Transformer.re
@@ -173,7 +173,7 @@ import Svg, {
   Ellipse,
   G,
   Text,
-  TSpan,
+  TSpan as Tspan,
   TextPath,
   Path,
   Polygon,

--- a/yarn.lock
+++ b/yarn.lock
@@ -175,10 +175,10 @@ braces@^3.0.1:
   dependencies:
     fill-range "^7.0.1"
 
-bs-platform@^7.0.0:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.1.tgz#1d7b0ef6088b998dceee5db74a7cd8f01c20a3bd"
-  integrity sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==
+bs-platform@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.1.0.tgz#72b52148b1c4be7f878969e6e2afd1bfab068cdd"
+  integrity sha512-XUeZf1nGzmsVymG89j5L8G9YNDHl0J/5iDGExXA7a4RKxnbvP2TselBZAzFeEH4rs3gG01b7yKt+h2pm7yh7Ww==
 
 callsites@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
Thanks for the this awesome lib. However, I found that `TSpan` is not properly imported. There are two ways to fix this. First is to fix the regex and the other is only aliasing the imported module from `react-native-svg`. 

The second one, since `bs-platform` is direct dipendency of this lib, I found that there will be warning because `bs-platform` is duplicated. So I move `bs-platform` to `peer deps`.


<img width="413" alt="Screen Shot 2020-02-12 at 20 23 39" src="https://user-images.githubusercontent.com/7804066/74338969-bd729f80-4dd5-11ea-8da3-fa6ae24e187b.png">

